### PR TITLE
Remove need to `use pyo3::types::PyDict`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # pyo3-testing Changelog
 
+## v0.3.4 Remove need to `use pyo3::types::PyDict`
+
+- Bring PyDict into scope in expanded testcase
+
 ## v0.3.3 & v0.3.2 Extend readme to include details on with_py_raises
 
 ## v0.3.1 Improve error messages for with_py_raises

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-testing"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 readme = "README.md"
 description = "Simplified testing for pyo3-wrapped functions"

--- a/src/pyo3test.rs
+++ b/src/pyo3test.rs
@@ -184,6 +184,7 @@ fn wrap_testcase(mut testcase: Pyo3TestCase) -> TokenStream2 {
     let mut testfn: ItemFn = parse_quote!(
         #[test]
         #testfn_signature {
+            use pyo3::types::PyDict;
             pyo3::prepare_freethreaded_python();
             Python::with_gil(|py| {
 
@@ -273,6 +274,7 @@ mod tests {
             #[test]
             #[anotherattribute]
             fn test_fizzbuzz() {
+                use pyo3::types::PyDict;
                 pyo3::prepare_freethreaded_python();
                 Python::with_gil(|py| {
                     let sys = PyModule::import_bound(py, "sys").unwrap();

--- a/tests/test_pyo3test.rs
+++ b/tests/test_pyo3test.rs
@@ -1,4 +1,4 @@
-use pyo3::{prelude::*, types::PyDict};
+use pyo3::prelude::*;
 use pyo3_testing::pyo3test;
 
 // The example from the Guide ...
@@ -44,6 +44,7 @@ fn py_adders(module: &Bound<'_, PyModule>) -> PyResult<()> {
 // adders.addone is correctly constructed.
 #[test]
 fn test_without_macro() {
+    use pyo3::types::PyDict;
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
         let sys = PyModule::import_bound(py, "sys").unwrap();

--- a/tests/test_withpyraises.rs
+++ b/tests/test_withpyraises.rs
@@ -1,4 +1,4 @@
-use pyo3::{exceptions::PyTypeError, prelude::*, types::PyDict};
+use pyo3::{exceptions::PyTypeError, prelude::*};
 use pyo3_testing::{pyo3test, with_py_raises};
 
 // The example from the Guide ...


### PR DESCRIPTION
Fixes #5