### PR TITLE
ensure CI fails if pyo3 version is bumped

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM ghcr.io/musicalninjas/pyo3-devcontainer:latest@sha256:e61ad9394071e19cdaff2dcd87dae9578d5f1d190f98956726187aa8d183bc9e

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,7 @@
 {
-    "image": "ghcr.io/musicalninjas/pyo3-devcontainer:latest@sha256:601b51f518504c3e0e4e668eea7d3213a65cf9e3d4f040d6d917c9269643e4f7",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
     "remoteEnv": {
         "RUSTC_BOOTSTRAP": "1"
     },

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,7 @@ proc-macro2 = "1.0.103"
 syn = {version = "2.0.111", features = ["full"]}
 pyo3 = "0.28.2"
 trybuild = "1.0.114"
+
+[dev-dependencies]
+cargo_metadata = "0.23.1"
+semver = "1.0.27"

--- a/tests/test_pyo3_version.rs
+++ b/tests/test_pyo3_version.rs
@@ -1,0 +1,56 @@
+//! Test to ensure CI fails if pyo3 version is bumped, so we can have a valid available version
+//! for every pyo3 going forwards.
+
+use std::{num::NonZeroU64, str::FromStr};
+
+use cargo_metadata::{MetadataCommand, PackageId};
+use semver::Version;
+
+/// Grabbed from cargo (crate), this is sadly hidden in a private module
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug, PartialOrd, Ord)]
+pub enum SemverCompatibility {
+    Major(NonZeroU64),
+    Minor(NonZeroU64),
+    Patch(u64),
+}
+
+impl From<&Version> for SemverCompatibility {
+    fn from(ver: &Version) -> Self {
+        if let Some(m) = NonZeroU64::new(ver.major) {
+            return SemverCompatibility::Major(m);
+        }
+        if let Some(m) = NonZeroU64::new(ver.minor) {
+            return SemverCompatibility::Minor(m);
+        }
+        SemverCompatibility::Patch(ver.patch)
+    }
+}
+
+/// Parse a PackageId to get the version. V ugly but not worth a newtype to impl Try_From
+fn version(pkg: &PackageId) -> Version {
+    let v = format!("{pkg}");
+    let v = v.split_once("@").unwrap().1;
+    Version::from_str(v).unwrap()
+}
+
+#[test]
+fn version_numbers_match() {
+    let cargo = MetadataCommand::new().exec().unwrap();
+    let pyo3testing = cargo
+        .packages
+        .iter()
+        .find(|pkg| pkg.name == "pyo3-testing")
+        .unwrap()
+        .version
+        .clone();
+    let deps = cargo.resolve.unwrap();
+    let root = &deps[deps.root.as_ref().unwrap()];
+    let pyo3 = &root.deps.iter().find(|pkg| pkg.name == "pyo3").unwrap().pkg;
+    let pyo3 = version(pyo3);
+    dbg!(&pyo3);
+    dbg!(&pyo3testing);
+    assert_eq!(
+        SemverCompatibility::from(&pyo3),
+        SemverCompatibility::from(&pyo3testing)
+    );
+}


### PR DESCRIPTION
so we can have a valid available version for every pyo3 going forwards

## Summary by Sourcery

Add a test and development tooling to ensure the crate’s pyo3 dependency stays semver-compatible with the pyo3-testing crate and provide a consistent devcontainer environment.

Enhancements:
- Add a devcontainer Dockerfile based on a pyo3-focused development image for consistent local and CI environments.

Tests:
- Add a test that compares the semver compatibility of the pyo3 dependency with the pyo3-testing crate version so CI fails when the pyo3 version is bumped without updating the test crate.

Chores:
- Add cargo_metadata and semver as dev-dependencies to support the new version compatibility test.